### PR TITLE
DEVEXP-514 First cut of docs for reading and writing

### DIFF
--- a/docs/reading.md
+++ b/docs/reading.md
@@ -1,0 +1,59 @@
+---
+layout: default
+title: Reading Documents
+nav_order: 4
+---
+
+The [GET /v1/documents](https://docs.marklogic.com/REST/GET/v1/documents) endpoint in the MarkLogic REST API supports
+reading multiple documents with metadata via a multipart/mixed HTTP response. The MarkLogic Python client simplifies
+handling the response by converting it into a list of `Document` instances via the `client.documents.read` method. 
+
+
+The examples below all assume that you have constructed a `Client` instance already as described in the 
+[Getting Started](getting-started.md) guide. The examples also assume the existence of documents with URIs of 
+`/doc1.json`, `/doc2.xml`, and `/doc3.bin`.
+
+## Reading documents
+
+A list of `Document` instances can be obtained for a list of URIs, where each `Document` has its `uri` and `content`
+attributes populated but no metadata by default:
+
+    docs = client.documents.read(["/doc1.json", "/doc2.xml"])
+
+The [requests toolbelt](https://toolbelt.readthedocs.io/en/latest/) library is used to process the multipart/mixed
+HTTP response returned by MarkLogic. As a result, the `content` attribute of each `Document` will be a binary value. 
+The client will convert this into something more useful based on the content types in the table below:
+
+| Content type | `content` attribute type |
+| --- | --- |
+| application/json | dictionary |
+| application/xml | string |
+| text/xml | string | 
+| text/plain | string |
+
+## Reading documents with metadata
+
+Metadata for each document can be retrieved via the `categories` argument. The acceptable values for this argument
+match those of the `category` parameter in the [GET /v1/documents](https://docs.marklogic.com/REST/GET/v1/documents)
+documentation: `content`, `metadata`, `metadata-values`, `collections`, `permissions`, `properties`, and `quality`.
+
+The following shows different examples of configuring the `categories` argument:
+
+```
+uris = ["/doc1.json", "/doc2.xml"]
+
+# Retrieve content and all metadata for each document.
+docs = client.documents.read(uris, categories=["content", "metadata"])
+
+# Retrieve content, collections, and permissions for each document.
+docs = client.documents.read(uris, categories=["content", "collections", "permissions"])
+
+# Retrieve only collections for each document; the content attribute will be None.
+docs = client.documents.read(uris, categories=["collections"])
+```
+
+# Error handling
+
+A GET call to the /v1/documents endpoint in MarkLogic will return an HTTP response with a status code of 200 for a
+successful request. For any other status code, the `client.documents.read` method will the `requests` `Response` object,
+providing access to the HTTP response returned by MarkLogic.

--- a/docs/writing.md
+++ b/docs/writing.md
@@ -1,0 +1,112 @@
+---
+layout: default
+title: Writing Documents
+nav_order: 3
+---
+
+The [POST /v1/documents](https://docs.marklogic.com/REST/POST/v1/documents) endpoint in the MarkLogic REST API supports
+writing multiple documents with metadata via a multipart/mixed HTTP request. The MarkLogic Python client 
+simplifies the task of constructing this multipart request via the `client.documents.write` method and the `Document`
+class. The examples below all assume that you have constructed a `Client` instance already as described in the 
+[Getting Started](getting-started.md) guide.
+
+## Writing documents with metadata
+
+Writing a document requires specifying a URI, the document content, and at least one update permission (a user with the
+"admin" role does not need to specify an update permission, but using such a user in an application is not encouraged):
+
+    from marklogic.documents import Document
+    default_perms = {"app-user": ["read", "update]}
+    response = client.documents.write([Document("/doc1.json", {"doc": 1}, permissions=default_perms)])
+
+The `write` method returns a `requests` `Response` instance, giving you access to everything returned by the REST API.
+
+The `Document` class supports all of the various kinds of metadata that can be assigned to a document:
+
+    doc = Document(
+        "/doc1.json", 
+        {"doc": 1},
+        permissions=default_perms,
+        collections=["c1", "c2"],
+        quality=10,
+        metadata_values={"key1": "value1", "key2": "value2"},
+        properties={"prop1": "value1", "prop2": 2}
+    )
+    client.documents.write([doc])
+
+Multiple documents can be written in a single call:
+
+    client.documents.write([
+        Document("/doc1.json", {"doc": 1}, permissions=default_perms)
+        Document("/doc2.json", {"doc": 2}, permissions=default_perms),
+    ])
+
+## Writing documents with different content types
+
+The examples above create documents with a dictionary as content, resulting in JSON documents in MarkLogic. An XML 
+document can be created with content defined via a string, including in the same request that creates a JSON document:
+
+    client.documents.write([
+        Document("/doc1.json", {"doc": 1}, permissions=default_perms)
+        Document("/doc2.xml", "<doc>2</doc>", permissions=default_perms),
+    ])
+
+Binary documents can be created by passing in binary content:
+
+    client.documents.write([Document("/doc1.bin", b"example content", permissions=default_perms)])
+
+A `Document` has a `content_type` attribute that allows for explicitly defining the 
+mimetype of a document. This feature is useful in a scenario where MarkLogic does not 
+have a mimetype registered for the URI extension, or there is no extension:
+
+    client.documents.write([Document(
+        "/doc1", "some text", 
+        permissions=default_perms, 
+        content_type="text/plain
+    )])
+
+
+## Specifying default metadata
+
+The documents REST endpoint allows for [default metadata](https://docs.marklogic.com/guide/rest-dev/bulk#id_16015) to 
+be specified for one or more documents. The client supports this by allowing a `DefaultMetadata` instance to be 
+included before any number of `Document` instances. Each `Document` will use the metadata in the `DefaultMetadata`
+instance, unless it specifies its own metadata. 
+
+Consider the following example:
+
+    from marklogic.documents import Document, DefaultMetadata
+    client.documents.write([
+        DefaultMetadata(perms=default_perms, collections=["example"]),
+        Document("/doc1.json", {"doc": 1}),
+        Document("/doc2.json", {"doc": 2", perms=default_perms, quality=10})
+    ])
+
+The first document will be written with the metadata specified in the first `DefaultMetadata` instance. The second
+document will not use the default metadata since it specifies its own metadata. It will have the same permissions, but 
+it will have a quality score of 10 and will not be assigned to the "example" collection.
+
+Multiple instances of `DefaultMetadata` can be included in the list passed to the `client.documents.write` method. If
+a `Document` instance does not specify any metadata, it will use the metadata found in the `DefaultMetadata` instance
+that occurs most recently before it in the list (if one exists). 
+
+## Additional control over writing a document
+
+The "Usage Notes" section in the [POST /v1/documents documentation](https://docs.marklogic.com/REST/POST/v1/documents)
+describes how several parameters can be used to control how each document is written. Those inputs are:
+
+1. `extension` = a URI suffix for use when [MarkLogic generates the URI](https://docs.marklogic.com/guide/rest-dev/bulk#id_86768).
+2. `directory` = a URI prefix for use when MarkLogic generates the URI.
+3. `repair` = level of XML repair to perform for an XML document.
+4. `extract` = whether or not to extract metadata for a binary document.
+5. `versionId` = can be used when optimistic locking is enabled.
+6. `temporal-document` = the logical document URI for a document in a temporal collection.
+
+Each of these can be specified on a `Document` instance, though `versionId` and `temporal-document` are named 
+`version_id` and `temporal_document` to align with Python naming conventions.
+
+The following shows an example of writing a document without specifying a URI, where the written document will have a 
+URI beginning with "/example/" and ending with ".json", with MarkLogic adding a random identifier in between to 
+construct the URI:
+
+    client.documents.write([Document(null, {"doc": 1}, extension=".json", directory="/example/")])

--- a/marklogic/documents.py
+++ b/marklogic/documents.py
@@ -282,13 +282,14 @@ def multipart_response_to_documents(response: Response) -> list[Document]:
         header_values = _extract_values_from_header(part)
         uri = header_values["uri"]
         if header_values["category"] == "content":
-            content = (
-                json.loads(part.content)
-                if header_values["content_type"] == "application/json"
-                else part.content
-            )
-            content_type = header_values["content_type"]
-            version_id = header_values["version_id"]
+            content = part.content
+            content_type = header_values.get("content_type")
+            if content_type == "application/json":
+                content = json.loads(content)
+            elif content_type in ["application/xml", "text/xml", "text/plain"]:
+                content = content.decode(part.encoding)
+
+            version_id = header_values.get("version_id")
             if uris_to_documents.get(uri):
                 doc: Document = uris_to_documents[uri]
                 doc.content = content
@@ -358,20 +359,20 @@ class DocumentManager:
         return self._session.post("/v1/documents", data=data, headers=headers, **kwargs)
 
     def read(
-        self, uris: list[str], categories: list[str] = None, **kwargs
+        self, uris: Union(str, list[str]), categories: list[str] = None, **kwargs
     ) -> Union[list[Document], Response]:
         """
         Read one or many documents via a GET to the endpoint defined at
         https://docs.marklogic.com/REST/POST/v1/documents . If a 200 is not returned
         by that endpoint, then the Response is returned instead.
 
-        :param uris: list of URIs to read.
+        :param uris: list of URIs or a single URI to read.
         :param categories: optional list of the categories of data to return for each
         URI. By default, only content will be returned for each URI. See the endpoint
         documentation for further information.
         """
         params = kwargs.pop("params", {})
-        params["uri"] = uris
+        params["uri"] = uris if isinstance(uris, list) else [uris]
         params["format"] = "json"  # This refers to the metadata format.
         if categories:
             params["category"] = categories
@@ -405,8 +406,8 @@ class DocumentManager:
         documents instead of a search response. Parameters that are commonly used for
         that endpoint are included as arguments to this method for ease of use.
 
-        :param query: JSON or XML query matching one of the types supported by the 
-        search endpoint. The "Content-type" header will be set based on whether this 
+        :param query: JSON or XML query matching one of the types supported by the
+        search endpoint. The "Content-type" header will be set based on whether this
         is a dict, a string of JSON, or a string of XML.
         :param categories: optional list of the categories of data to return for each
         URI. By default, only content will be returned for each URI. See the endpoint

--- a/tests/test_read_documents.py
+++ b/tests/test_read_documents.py
@@ -19,12 +19,40 @@ def test_write_and_read_binary(client: Client):
     )
     assert 200 == response.status_code
 
-    docs = client.documents.read(["/temp/doc1.bin"])
+    docs = client.documents.read("/temp/doc1.bin")
     assert len(docs) == 1
     doc = docs[0]
     assert doc.uri == "/temp/doc1.bin"
     content = doc.content.decode("ascii")
     assert content == "MarkLogic and Python"
+
+
+def test_write_and_read_xml_document(client: Client):
+    response = client.documents.write(
+        [Document("/doc1.xml", "<hello>world</hello>", permissions=DEFAULT_PERMS)]
+    )
+    assert response.status_code == 200
+
+    doc = client.documents.read("/doc1.xml")[0]
+    # Verify content was turned into a string
+    assert "<hello>world</hello>" in doc.content
+
+
+def test_write_and_read_text_document(client: Client):
+    response = client.documents.write(
+        [
+            Document(
+                "/doc1.txt",
+                "hello world!",
+                permissions=DEFAULT_PERMS,
+                content_type="text/plain",
+            )
+        ]
+    )
+    assert response.status_code == 200
+
+    doc = client.documents.read("/doc1.txt")[0]
+    assert doc.content == "hello world!"
 
 
 def test_read_uri_with_double_quotes(client: Client):
@@ -34,13 +62,13 @@ def test_read_uri_with_double_quotes(client: Client):
     )
     assert response.status_code == 200
 
-    docs = client.documents.read(["/this/%22works.json"])
+    docs = client.documents.read("/this/%22works.json")
     assert len(docs) == 1
     assert "/this/%22works.json" == docs[0].uri
 
 
 def test_uri_not_found(client: Client):
-    docs = client.documents.read(["/doesnt-exist.json"])
+    docs = client.documents.read("/doesnt-exist.json")
     assert docs is not None
     assert len(docs) == 0
 
@@ -92,7 +120,7 @@ def test_with_accept_header(client: Client):
     expected to be set to multipart/mixed by the client.
     """
     docs = client.documents.read(
-        ["/doc1.json"],
+        "/doc1.json",
         headers={"Accept": "something/invalid"},
         categories=["content", "quality"],
     )
@@ -107,7 +135,7 @@ def test_with_accept_header(client: Client):
 
 def test_read_with_basic_client(basic_client: Client):
     # Just verifies that basic auth works as expected.
-    doc = basic_client.documents.read(["/doc1.json"])[0]
+    doc = basic_client.documents.read("/doc1.json")[0]
     assert {"hello": "world"} == doc.content
 
 


### PR DESCRIPTION

Also modified the `read` method to accept a single string instead of always requiring a list.

My thoughts is I'll do the following next:

1. Write docs for searching.
2. Review the 4 pages of docs and clean them up in another PR. 