### PR TITLE
DEVEXP-514 Added docs for reading, writing, and searching

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -9,49 +9,70 @@ MarkLogic Python client into a Python virtual environment.
 
 ## Connecting to MarkLogic
 
-(TODO This will almost certainly be reorganized before the 1.0 release.)
-
 The `Client` class is the primary API to interact with in the MarkLogic Python client. The
 `Client` class extends the `requests` 
 [`Session` class](https://docs.python-requests.org/en/latest/user/advanced/#session-objects), thus exposing all methods
 found in both the `Session` class and the `requests` API. You can therefore use a `Client` object in the same manner 
 as you'd use either the `Session` class or the `requests` API.
 
+To try out any of the examples below or in the rest of this guide, you will first need to create a new MarkLogic user. 
+To do so, please go to the Admin application for your MarkLogic instance - e.g. if you are running MarkLogic locally, 
+this will be at <http://localhost:8001>, and you will authenticate as your "admin" user. Then perform the following 
+steps to create a new user:
+
+1. Click on "Users" in the "Security" box.
+2. Click on "Create".
+3. In the form, enter "python-user" for "User Name" and "pyth0n" as the password. 
+4. Scroll down until you see the "Roles" section. Click on the "rest-reader" and "rest-writer" checkboxes. 
+5. Scroll to the top or bottom and click on "OK" to create the user.
+
 A `Client` instance can be constructed either by providing a base URL for all requests along with authentication:
 
-    from marklogic import Client
-    client = Client('http://localhost:8030', digest=('username', 'password'))
+```
+from marklogic import Client
+client = Client('http://localhost:8000', digest=('python-user', 'pyth0n'))
+```
 
 Or via separate arguments for each of the parts of a base URL:
 
-    from marklogic import Client
-    client = Client(host='localhost', port='8030', digest=('username', 'password'))
+```
+from marklogic import Client
+client = Client(host='localhost', port='8000', digest=('python-user', 'pyth0n'))
+```
 
 After constructing a `Client` instance, each of the methods in the `requests` API for sending an HTTP request can be 
 used without needing to specify the base URL nor the authentication again. For example:
 
-    response = client.post('/v1/search')
-    response = client.get('/v1/documents', params={'uri': '/my-doc.json'})
+```
+response = client.post('/v1/search')
+response = client.get('/v1/documents', params={'uri': '/my-doc.json'})
+```
 
 Because the `Client` class extends the `Sessions` class, it can be used as a context manager:
 
-    with Client('http://localhost:8030', digest=('username', 'password')) as client:
-        response = client.post('/v1/search')
-        response = client.get('/v1/documents', params={'uri': '/my-doc.json'})
+```
+with Client('http://localhost:8000', digest=('python-user', 'pyth0n')) as client:
+    response = client.post('/v1/search')
+    response = client.get('/v1/documents', params={'uri': '/my-doc.json'})
+```
 
 ## Authentication
 
 The `Client` constructor includes a `digest` argument as a convenience for using digest authentication:
 
-    from marklogic import Client
-    client = Client('http://localhost:8030', digest=('username', 'password'))
+```
+from marklogic import Client
+client = Client('http://localhost:8000', digest=('python-user', 'pyth0n'))
+```
 
 An `auth` argument is also available for using any authentication strategy that can be configured
 [via the requests `auth` argument](https://requests.readthedocs.io/en/latest/user/advanced/#custom-authentication). For 
 example, just like with `requests`, a tuple can be passed to the `auth` argument to use basic authentication:
 
-    from marklogic import Client
-    client = Client('http://localhost:8030', auth=('username', 'password'))
+```
+from marklogic import Client
+client = Client('http://localhost:8000', auth=('python-user', 'pyth0n'))
+```
 
 ### MarkLogic Cloud Authentication
 
@@ -59,23 +80,29 @@ When connecting to a [MarkLogic Cloud instance](https://developer.marklogic.com/
 the `cloud_api_key` and `base_path` arguments. You only need to specify a `host` as well, as port 443 and HTTPS will be
 used by default. For example:
 
-    from marklogic import Client
-    client = Client(host='example.marklogic.cloud', cloud_api_key='some-key-value', base_path='/ml/example/manage')
+```
+from marklogic import Client
+client = Client(host='example.marklogic.cloud', cloud_api_key='some-key-value', base_path='/ml/example/manage')
+```
 
 You may still use a full base URL if you wish:
 
-    from marklogic import Client
-    client = Client('https://example.marklogic.cloud', cloud_api_key='some-key-value', base_path='/ml/example/manage')
+```
+from marklogic import Client
+client = Client('https://example.marklogic.cloud', cloud_api_key='some-key-value', base_path='/ml/example/manage')
+```
 
 MarkLogic Cloud uses an access token for authentication; the access token is generated using the API key value. In some 
 scenarios, you may wish to set the token expiration time to a value other than the default used by MarkLogic Cloud. To 
 do so, set the `cloud_token_duration` argument to a number greater than zero that defines the token duration in 
 minutes:
 
-    from marklogic import Client
-    # Sets a token duration of 10 minutes.
-    client = Client(host='example.marklogic.cloud', cloud_api_key='some-key-value', base_path='/ml/example/manage', 
-        cloud_token_duration=10)
+```
+from marklogic import Client
+# Sets a token duration of 10 minutes.
+client = Client(host='example.marklogic.cloud', cloud_api_key='some-key-value', base_path='/ml/example/manage', 
+    cloud_token_duration=10)
+```
 
 ## SSL 
 
@@ -84,10 +111,14 @@ Configuring SSL connections is the same as
 As a convience, the `Client` constructor includes a `verify` argument so that it does not need to be configured on the 
 `Client` instance after it's been constructed nor on every request:
 
-    from marklogic import Client
-    client = Client('https://localhost:8030', digest=('username', 'password'), verify='/path/to/cert.pem')
+```
+from marklogic import Client
+client = Client('https://localhost:8000', digest=('python-user', 'pyth0n'), verify='/path/to/cert.pem')
+```
 
 When specifying the base URL via separate arguments, the `scheme` argument can be set for HTTPS connections:
 
-    from marklogic import Client
-    client = Client(host='localhost', port='8030', scheme='https', digest=('username', 'password'), verify=False)
+```
+from marklogic import Client
+client = Client(host='localhost', port='8000', scheme='https', digest=('python-user', 'pyth0n'), verify=False)
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,3 +7,6 @@ nav_order: 1
 The MarkLogic Python Client further simplifies usage of the 
 [Python `requests` library](https://pypi.org/project/requests/) when developing applications in Python that communicate
 with the [MarkLogic REST API](https://docs.marklogic.com/guide/rest-dev). 
+
+See the [Getting Started guide](getting-started.md) to begin using the client.
+

--- a/docs/managing-documents/managing-documents.md
+++ b/docs/managing-documents/managing-documents.md
@@ -1,0 +1,32 @@
+---
+layout: default
+title: Managing Documents
+nav_order: 3
+has_children: true
+permalink: /docs/managing-documents
+---
+
+The [/v1/documents endpoint](https://docs.marklogic.com/REST/client/management) in the MarkLogic REST API simplifies
+operations that involve writing or reading a single document. It also supports operations that involve multiple 
+documents, though those require use of a potentially complex multipart HTTP request or response. The MarkLogic Python
+client simplifies those operations by hiding the details of multipart requests and responses.
+
+## Setup for examples
+
+The examples shown in [Reading Documents](reading.md) and [Searching Documents](searching.md) assume that you have 
+created a new MarkLogic user named "python-user" as described in the [Getting Started](getting-started.md) guide. 
+The examples also depend on documents being created by the below script. If you would like to run each of the examples, 
+please run the script below, which will create a `Client` instance that interacts with the out-of-the-box "Documents"
+database in MarkLogic.
+
+```
+from marklogic import Client
+from marklogic.documents import Document, DefaultMetadata
+
+client = Client('http://localhost:8000', digest=('python-user', 'pyth0n'))
+client.documents.write([
+    DefaultMetadata(permissions={"rest-reader": ["read", "update"]}, collections=["python-example"]),
+    Document("/doc1.json", {"text": "example one"}),
+    Document("/doc2.json", {"text": "example two"})
+])
+```

--- a/docs/managing-documents/reading.md
+++ b/docs/managing-documents/reading.md
@@ -1,0 +1,94 @@
+---
+layout: default
+title: Reading Documents
+parent: Managing Documents
+nav_order: 3
+---
+
+The [GET /v1/documents](https://docs.marklogic.com/REST/GET/v1/documents) endpoint in the MarkLogic REST API supports
+reading multiple documents with metadata via a multipart/mixed HTTP response. The MarkLogic Python client simplifies
+handling the response by converting it into a list of `Document` instances via the `client.documents.read` method. 
+
+## Setup for examples
+
+The examples below all assume that you have created a new MarkLogic user named "python-user" as described in the 
+[Getting Started](getting-started.md) guide. To run these examples, please run the following script first, which will 
+create a `Client` instance that interacts with the out-of-the-box "Documents" database in MarkLogic:
+```
+from marklogic import Client
+from marklogic.documents import Document, DefaultMetadata
+
+client = Client('http://localhost:8000', digest=('python-user', 'pyth0n'))
+client.documents.write([
+    DefaultMetadata(permissions={"rest-reader": ["read", "update"]}, collections=["python-example"]),
+    Document("/doc1.json", {"text": "example one"}),
+    Document("/doc2.xml", "<text>example two</text>"),
+    Document("/doc3.bin", b"binary example", permissions={"rest-reader": ["read", "update"]})
+])
+```
+
+## Reading documents
+
+A list of `Document` instances can be obtained for a list of URIs, where each `Document` has its `uri` and `content`
+attributes populated but no metadata by default:
+
+```
+docs = client.documents.read(["/doc1.json", "/doc2.xml", "/doc3.bin"])
+assert len(docs) == 3
+```
+
+The [requests toolbelt](https://toolbelt.readthedocs.io/en/latest/) library is used to process the multipart
+HTTP response returned by MarkLogic. By default, the `content` attribute of each `Document` will be a binary value. 
+The client will convert this into something more useful based on the content types in the table below:
+
+| Content type | `content` attribute type |
+| --- | --- |
+| application/json | dictionary |
+| application/xml | string |
+| text/xml | string | 
+| text/plain | string |
+
+Thus, the `Document` with a URI of "/doc1.json" will have a dictionary as the value of its 
+`content` attribute. The `Document` with a URI of "/doc2.xml" will have a string as the value of its `content`
+attribute. And the `Docuemnt` with a URI of "/doc3.bin" will have a binary value for its `content` attribute.
+
+A `Document` instance can be examined simply by printing or logging it; this will display all of the instance's 
+changeable attributes, including the URI, content, and metadata:
+
+```
+doc = docs[0]
+print(doc)
+
+# Can always built-in Python vars method.
+print(vars(doc))
+```
+
+## Reading documents with metadata
+
+Metadata for each document can be retrieved via the `categories` argument. The acceptable values for this argument
+match those of the `category` parameter in the [GET /v1/documents](https://docs.marklogic.com/REST/GET/v1/documents)
+documentation: `content`, `metadata`, `metadata-values`, `collections`, `permissions`, `properties`, and `quality`.
+
+The following shows different examples of configuring the `categories` argument:
+
+```
+uris = ["/doc1.json", "/doc2.xml", "/doc3.bin"]
+
+# Retrieve content and all metadata for each document.
+docs = client.documents.read(uris, categories=["content", "metadata"])
+print(docs)
+
+# Retrieve content, collections, and permissions for each document.
+docs = client.documents.read(uris, categories=["content", "collections", "permissions"])
+print(docs)
+
+# Retrieve only collections for each document; the content attribute will be None.
+docs = client.documents.read(uris, categories=["collections"])
+print(docs)
+```
+
+# Error handling
+
+A GET call to the /v1/documents endpoint in MarkLogic will return an HTTP response with a status code of 200 for a
+successful request. For any other status code, the `client.documents.read` method will the `requests` `Response` object,
+providing access to the error details returned by MarkLogic.

--- a/docs/managing-documents/searching.md
+++ b/docs/managing-documents/searching.md
@@ -1,0 +1,153 @@
+---
+layout: default
+title: Searching Documents
+parent: Managing Documents
+nav_order: 3
+---
+
+The [POST /v1/search endpoint](https://docs.marklogic.com/REST/POST/v1/search) in the MarkLogic REST API supports
+returning content and metadata for each matching document. Similar to reading multiple documents via the 
+[GET /v1/documents endpoint](https://docs.marklogic.com/REST/GET/v1/documents, the data is returned in a multipart
+HTTP response. The MarkLogic Python client simplifies use of this operation by returning a list of `Document` instances
+via the `client.documents.search` method.
+
+## Setup for examples
+
+The examples below all assume that you have created a new MarkLogic user named "python-user" as described in the 
+[Getting Started](getting-started.md) guide. To run these examples, please run the following script first, which will 
+create a `Client` instance that interacts with the out-of-the-box "Documents" database in MarkLogic:
+```
+from marklogic import Client
+from marklogic.documents import Document, DefaultMetadata
+
+client = Client('http://localhost:8000', digest=('python-user', 'pyth0n'))
+client.documents.write([
+    DefaultMetadata(permissions={"rest-reader": ["read", "update"]}, collections=["python-example"]),
+    Document("/doc1.json", {"text": "example one"}),
+    Document("/doc2.json", {"text": "example two"})
+])
+```
+
+## Searching via a search string
+
+The search endpoint in the REST API provides several ways of submitting a query. The simplest approach is by submitting
+a search string that utilizes the
+[the MarkLogic search grammar](https://docs.marklogic.com/guide/search-dev/search-api#id_41745):
+
+```
+# Find documents with the term "example" in them.
+docs = client.documents.search("example")
+assert len(docs) == 2
+
+# Find documents with the term "one" in them.
+docs = client.documents.search("one")
+assert len(docs) == 1
+```
+
+The search string in the example corresponds to the `q` argument, which is the first argument in the method and thus
+does not need to be named. 
+
+## Searching via a complex query
+
+More complex queries can be submitted via the `query` parameter. The value of this parameter must be one of the
+following:
+
+1. A [structured query](https://docs.marklogic.com/guide/search-dev/structured-query#).
+2. A [serialized CTS query](https://docs.marklogic.com/guide/rest-dev/search#id_30577).
+3. A [combined query](https://docs.marklogic.com/guide/rest-dev/search#id_69918).
+
+For each of the above approaches, the query can be either a dictionary (for use when defining the query via JSON) or 
+a string of XML. Based on the type, the client will set the appropriate Content-type header. 
+
+Examples of a structured query:
+
+```
+# JSON
+docs = client.documents.search(query={"query": {"term-query": {"text": "example"}}})
+assert len(docs) == 2
+
+# XML
+query = "<query xmlns='http://marklogic.com/appservices/search'>\
+        <term-query><text>example</text></term-query></query>"
+docs = client.documents.search(query=query)
+assert len(docs) == 2
+```
+
+Examples of a serialized CTS query:
+
+```
+# JSON
+query = {"ctsquery": {"wordQuery": {"text": "example"}}}
+docs = client.documents.search(query=query)
+assert len(docs) == 2
+
+# XML
+query = "<word-query xmlns='http://marklogic.com/cts'><text>world</text></word-query>"
+docs = client.documents.search(query=query)
+assert len(docs) == 2
+```
+
+Examples of a combined query:
+
+```
+# JSON
+options = {"constraint": {"name": "c1", "word": {"element": {"name": "text"}}}}
+query = {
+    "search": {"options": options},
+    "qtext": "c1:example",
+}
+docs = client.documents.search(query=query)
+assert len(docs) == 2
+
+# XML
+query = "<search xmlns='http://marklogic.com/appservices/search'><options>\
+        <constraint name='c1'><word><element name='text'/></word></constraint>\
+        </options><qtext>c1:example</qtext></search>"
+docs = client.documents.search(query=query)
+assert len(docs) == 2
+```
+
+## Controlling search results
+
+The search endpoint supports a variety of parameters for controlling the search request. For convenience, several of the
+more commonly used parameters are available as arguments in the `client.documents.search` method:
+
+```
+# Specify the starting point and page length.
+docs = client.documents.search("example", start=2, page_length=5)
+assert len(docs) == 1
+
+# Search via a collection without any search string.
+docs = client.documents.search(collections=["python-example"])
+assert len(docs) == 2
+```
+
+Similar to [reading documents](reading.md), you can use the `categories` argument to control what is returned for 
+each matching document:
+
+```
+# Retrieve all content and metadata for each matching document.
+docs = client.documents.search("example", categories=["content", "metadata"])
+assert "python-example" in docs[0].collections
+assert "python-example" in docs[1].collections
+
+# Retrieve only permissions for each matching document.
+docs = client.documents.search("example", categories=["permissions"])
+assert docs[0].content is None
+assert docs[1].content is None
+```
+
+The `client.documents.search` method provides a `**kwargs` argument, so you can pass in any other arguments you would
+normally pass to `requests`, such as a `params` argument that specifies additional parameters:
+
+
+```
+docs = client.documents.search("example", params={"database": "Documents"})
+assert len(docs) == 2
+```
+
+# Error handling
+
+A POST call to the /v1/search endpoint in MarkLogic will return an HTTP response with a status code of 200 for a
+successful request. For any other status code, the `client.documents.search` method will the `requests` `Response` object,
+providing access to the error details returned by MarkLogic.

--- a/docs/managing-documents/writing.md
+++ b/docs/managing-documents/writing.md
@@ -1,0 +1,115 @@
+---
+layout: default
+title: Writing Documents
+nav_order: 2
+parent: Managing Documents
+---
+
+The [POST /v1/documents](https://docs.marklogic.com/REST/POST/v1/documents) endpoint in the MarkLogic REST API supports
+writing multiple documents with metadata via a multipart HTTP request. The MarkLogic Python client 
+simplifies the use of this endpoint via the `client.documents.write` method and the `Document`
+class. The examples below all assume that you have constructed a `Client` instance already as described in the 
+[Getting Started](getting-started.md) guide.
+
+## Writing documents with metadata
+
+Writing a document requires specifying a URI, the document content, and at least one update permission (a user with the
+"admin" role does not need to specify an update permission, but using such a user in an application is not encouraged).
+The example below demonstrates this; the `default_perms` variable is used in subsequent examples. 
+
+    from marklogic.documents import Document
+    default_perms = {"rest-reader": ["read", "update"]}
+    response = client.documents.write(Document("/doc1.json", {"doc": 1}, permissions=default_perms))
+
+The `write` method returns a [Response instance](https://requests.readthedocs.io/en/latest/api/#requests.Response) 
+from the `requests` API, giving you access to everything returned by the MarkLogic REST API.
+
+The `Document` class supports all of the types of metadata that can be assigned to a document:
+
+    doc = Document(
+        "/doc1.json", 
+        {"doc": 1},
+        permissions=default_perms,
+        collections=["c1", "c2"],
+        quality=10,
+        metadata_values={"key1": "value1", "key2": "value2"},
+        properties={"prop1": "value1", "prop2": 2}
+    )
+    client.documents.write(doc)
+
+Multiple documents can be written in a single call, each with their own metadata:
+
+    client.documents.write([
+        Document("/doc1.json", {"doc": 1}, permissions=default_perms, collections=["example"])
+        Document("/doc2.json", {"doc": 2}, permissions=default_perms, quality=5),
+    ])
+
+## Writing documents with different content types
+
+The examples above create documents with a dictionary as content, resulting in JSON documents in MarkLogic. An XML 
+document can be created with content defined via a string, including in the same request that creates a JSON document:
+
+    client.documents.write([
+        Document("/doc1.json", {"doc": 1}, permissions=default_perms)
+        Document("/doc2.xml", "<doc>2</doc>", permissions=default_perms),
+    ])
+
+Binary documents can be created by passing in binary content:
+
+    client.documents.write([Document("/doc1.bin", b"example content", permissions=default_perms)])
+
+A `Document` has a `content_type` attribute that allows for explicitly defining the 
+mimetype of a document. This feature is useful in a scenario where MarkLogic does not 
+have a mimetype registered for the URI extension, or there is no extension:
+
+    client.documents.write([Document(
+        "/doc1", "some text", 
+        permissions=default_perms, 
+        content_type="text/plain
+    )])
+
+
+## Specifying default metadata
+
+The documents REST endpoint allows for [default metadata](https://docs.marklogic.com/guide/rest-dev/bulk#id_16015) to 
+be specified for one or more documents. The client supports this by allowing a `DefaultMetadata` instance to be 
+included before any number of `Document` instances. Each `Document` will use the metadata in the `DefaultMetadata`
+instance, unless it specifies its own metadata. 
+
+Consider the following example:
+
+    from marklogic.documents import Document, DefaultMetadata
+    client.documents.write([
+        DefaultMetadata(perms=default_perms, collections=["example"]),
+        Document("/doc1.json", {"doc": 1}),
+        Document("/doc2.json", {"doc": 2", perms=default_perms, quality=10})
+    ])
+
+The first document will be written with the metadata specified in the first `DefaultMetadata` instance. The second
+document will not use the default metadata since it specifies its own metadata. It will have the same permissions, but 
+it will have a quality score of 10 and will not be assigned to the "example" collection.
+
+Multiple instances of `DefaultMetadata` can be included in the list passed to the `client.documents.write` method. If
+a `Document` instance does not specify any metadata, it will use the metadata found in the `DefaultMetadata` instance
+that occurs most recently before it in the list (if one exists). 
+
+## Additional control over writing a document
+
+The "Usage Notes" section in the [POST /v1/documents documentation](https://docs.marklogic.com/REST/POST/v1/documents)
+describes how several parameters can be used to control how each document is written. Those inputs are:
+
+1. `extension` = a URI suffix for use when [MarkLogic generates the URI](https://docs.marklogic.com/guide/rest-dev/bulk#id_86768).
+2. `directory` = a URI prefix for use when MarkLogic generates the URI.
+3. `repair` = level of XML repair to perform for an XML document.
+4. `extract` = whether or not to extract metadata for a binary document.
+5. `versionId` = can be used when optimistic locking is enabled.
+6. `temporal-document` = the logical document URI for a document in a temporal collection.
+
+Each of these can be specified on a `Document` instance, though `versionId` and `temporal-document` are named 
+`version_id` and `temporal_document` to align with Python naming conventions.
+
+The following shows an example of writing a document without specifying a URI, where the written document will have a 
+URI beginning with "/example/" and ending with ".json", with MarkLogic adding a random identifier in between to 
+construct the URI:
+
+    client.documents.write([Document(null, {"doc": 1}, extension=".json", directory="/example/")])

--- a/marklogic/documents.py
+++ b/marklogic/documents.py
@@ -144,6 +144,24 @@ class Document(Metadata):
         self.extract = extract
         self.temporal_document = temporal_document
 
+    @property
+    def metadata(self):
+        """
+        Returns a dict containing the 5 attributes that comprise the metadata of a 
+        document in MarkLogic.
+        """
+        return {
+            "permissions": self.permissions,
+            "collections": self.collections,
+            "quality": self.quality,
+            "metadata_values": self.metadata_values,
+            "properties": self.properties,
+        }
+
+    def __repr__(self):
+        # Print all class attributes for easy inspection.
+        return "{!r}".format(self.__dict__)
+
     def to_request_field(self) -> RequestField:
         """
         Returns a multipart request field representing the document to be written.
@@ -398,9 +416,9 @@ class DocumentManager:
 
     def search(
         self,
+        q: str = None,
         query: Union[dict, str] = None,
         categories: list[str] = None,
-        q: str = None,
         start: int = None,
         page_length: int = None,
         options: str = None,

--- a/poetry.lock
+++ b/poetry.lock
@@ -249,7 +249,7 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "6e750292896cdb4027ec135cc05558f8a3718e92bb70d3dc9f3f6f52ebea3fa0"
+content-hash = "04c1fff7ce44488837c853d4e231dc9a0c7c901af9b13dfca493098292e8253a"
 
 [metadata.files]
 black = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ license = "Apache 2.0"
 [tool.poetry.dependencies]
 python = "^3.9"
 requests = "^2.31.0"
-requests_toolbelt = "1.0.0"
+requests_toolbelt = "^1.0.0"
 
 [tool.poetry.group.test.dependencies]
 pytest = "^7.4.0"

--- a/tests/test_search_docs.py
+++ b/tests/test_search_docs.py
@@ -24,6 +24,37 @@ def test_structured_xml_query(client: Client):
     assert len(docs) == 2
 
 
+def test_serialized_cts_json_query(client: Client):
+    query = {"ctsquery": {"wordQuery": {"text": "world"}}}
+    docs = client.documents.search(query=query)
+    assert len(docs) == 2
+
+
+def test_serialized_cts_xml_query(client: Client):
+    query = "<word-query xmlns='http://marklogic.com/cts'>\
+        <text>world</text></word-query>"
+    docs = client.documents.search(query=query)
+    assert len(docs) == 2
+
+
+def test_combined_json_query(client: Client):
+    options = {"constraint": {"name": "c1", "value": {"element": {"name": "hello"}}}}
+    query = {
+        "search": {"options": options},
+        "qtext": "c1:world",
+    }
+    docs = client.documents.search(query=query)
+    assert len(docs) == 2
+
+
+def test_combined_xml_query(client: Client):
+    query = "<search xmlns='http://marklogic.com/appservices/search'><options>\
+        <constraint name='c1'><value><element name='hello'/></value></constraint>\
+        </options><qtext>c1:world</qtext></search>"
+    docs = client.documents.search(query=query)
+    assert len(docs) == 2
+
+
 def test_qtext_and_start(client: Client):
     docs = client.documents.search(q="world", start=2)
     assert len(docs) == 1, "2 docs match, but start=2, so only 1 should be returned"


### PR DESCRIPTION
Couple small code changes:

- `Document` now has a useful overriden "repr" method, along with a `metadata` getter for inspection purposes.
- Moved `q` to be the first arg for `search` so that a user doesn't have to type "q=" for the common use case of specifying a search string. 