### PR TITLE
Returning None instead of empty array

### DIFF
--- a/marklogic/client.py
+++ b/marklogic/client.py
@@ -100,7 +100,8 @@ class Client(requests.Session):
         """
         Send a script to MarkLogic via a POST to the endpoint
         defined at https://docs.marklogic.com/REST/POST/v1/eval. Must define either
-        'javascript' or 'xquery'.
+        'javascript' or 'xquery'. Returns a list, unless no content is returned in
+        which case None is returned.
 
         :param javascript: a JavaScript script
         :param xquery: an XQuery script
@@ -141,7 +142,8 @@ class Client(requests.Session):
         """
         Send a script (XQuery or JavaScript) and possibly a dict of vars
         to MarkLogic via a POST to the endpoint defined at
-        https://docs.marklogic.com/REST/POST/v1/eval.
+        https://docs.marklogic.com/REST/POST/v1/eval. Returns a list, unless no content
+        is returned in which case None is returned.
 
         :param module: The URI of a module in the modules database of the app server
         :param vars: a dict containing variables to include

--- a/marklogic/internal/eval.py
+++ b/marklogic/internal/eval.py
@@ -20,7 +20,7 @@ def process_multipart_mixed_response(response: Response) -> list:
     MarkLogic server.
     """
     if response_has_no_content(response):
-        return []
+        return None
 
     parts = MultipartDecoder.from_response(response).parts
     transformed_parts = []

--- a/marklogic/rows.py
+++ b/marklogic/rows.py
@@ -94,7 +94,7 @@ class RowManager:
         )
         if response.ok and not return_response:
             if response_has_no_content(response):
-                return []
+                return None
             return (
                 response.json()
                 if graphql

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -100,7 +100,7 @@ def test_javascript_vars(client):
 
 def test_xquery_empty_sequence(client):
     parts = client.eval(xquery="()")
-    assert [] == parts
+    assert parts is None
 
 
 def test_javascript_empty_array(client):
@@ -110,7 +110,7 @@ def test_javascript_empty_array(client):
 
 def test_javascript_empty_sequence(client):
     parts = client.eval(javascript="Sequence.from([])")
-    assert [] == parts
+    assert parts is None
 
 
 def test_base64Binary(client):

--- a/tests/test_rows.py
+++ b/tests/test_rows.py
@@ -17,7 +17,7 @@ def test_dsl_default(client):
 def test_no_rows_returned(client):
     query = 'op.fromView("test", "musician").where(op.eq(op.col("lastName"), "Smith"))'
     results = client.rows.query(query)
-    assert [] == results
+    assert results is None
 
 
 def test_dsl_default_return_response(client):
@@ -98,7 +98,7 @@ def test_transaction(client):
         query = f'op.fromView("test", "musician")'
         query = f'{query}.where(op.eq(op.col("lastName"), "{lastName}"))'
         results = client.rows.query(query, tx=tx)
-        assert len(results) == 0
+        assert results is None
 
         perms = {"python-tester": ["read", "update"]}
         doc = Document(uri, content, permissions=perms)
@@ -109,7 +109,7 @@ def test_transaction(client):
 
         client.delete("/v1/documents", params={"uri": uri, "txid": tx.id})
         results = client.rows.query(query, tx=tx)
-        assert len(results) == 0
+        assert results is None
 
 
 def verify_four_musicians_are_returned_in_json(data, column_name):


### PR DESCRIPTION
This seems like the right choices for v1/rows, where a JSON object is returned by default. For eval, an "empty sequence" is different from an "empty array" - an empty array is something that still exists (an array with no items in it) - and so when an empty sequence is returned for eval/invoke, None seems more appropriate too. 