### PR TITLE
Added TOC and info on kwargs for eval/rows

### DIFF
--- a/docs/creating-client.md
+++ b/docs/creating-client.md
@@ -11,6 +11,12 @@ The `Client` class is the primary API to interact with in the MarkLogic Python c
 found in both the `Session` class and the `requests` API. You can therefore use a `Client` object in the same manner 
 as you'd use either the `Session` class or the `requests` API.
 
+## Table of contents
+{: .no_toc .text-delta }
+
+- TOC
+{:toc}
+
 ## Creating a client
 
 A `Client` instance can be created either by providing a base URL for all requests along with authentication:

--- a/docs/eval.md
+++ b/docs/eval.md
@@ -9,6 +9,12 @@ execution of custom code, whether via an inline script or an existing module in 
 The MarkLogic Python client supports execution of custom code by simplifying the submission of custom code
 and converting the multipart response into more useful Python data types.
 
+## Table of contents
+{: .no_toc .text-delta }
+
+- TOC
+{:toc}
+
 ## Setup
 
 The examples below all depend on the instructions in the [setup guide](example-setup.md) having already been performed.
@@ -117,3 +123,17 @@ processing of the response or debugging requests.
 The `client.eval` and `client.invoke` functions both support referencing a 
 [REST API transaction](https://docs.marklogic.com/REST/client/transaction-management) via the `tx` 
 argument. See [the guide on transactions](transactions.md) for further information.
+
+## Providing additional arguments
+
+The `client.eval` and `client.invoke` methods each provide a `**kwargs` argument, so you can pass in any other arguments you would
+normally pass to `requests`. For example:
+
+```
+client.eval(javascript="fn.currentDateTime()", params={"database": "Documents"})
+client.invoke("/sample.sjs", params={"database": "Documents"})
+```
+
+Please see [the eval endpoint documentation](https://docs.marklogic.com/REST/POST/v1/eval) 
+and [the invoke endpoint documentation](https://docs.marklogic.com/REST/POST/v1/invoke) for
+information on additional parameters.

--- a/docs/managing-documents/reading.md
+++ b/docs/managing-documents/reading.md
@@ -10,6 +10,12 @@ The [GET /v1/documents](https://docs.marklogic.com/REST/GET/v1/documents) endpoi
 reading multiple documents with metadata via a multipart/mixed HTTP response. The MarkLogic Python client simplifies
 handling the response by converting it into a list of `Document` instances via the `client.documents.read` method. 
 
+## Table of contents
+{: .no_toc .text-delta }
+
+- TOC
+{:toc}
+
 ## Setup for examples
 
 The examples below all assume that you have created a new MarkLogic user named "python-user" as described in the 

--- a/docs/managing-documents/searching.md
+++ b/docs/managing-documents/searching.md
@@ -12,6 +12,12 @@ returning content and metadata for each matching document. Similar to reading mu
 HTTP response. The MarkLogic Python client simplifies use of this operation by returning a list of `Document` instances
 via the `client.documents.search` method.
 
+## Table of contents
+{: .no_toc .text-delta }
+
+- TOC
+{:toc}
+
 ## Setup for examples
 
 The examples below all assume that you have created a new MarkLogic user named "python-user" as described in the 

--- a/docs/managing-documents/writing.md
+++ b/docs/managing-documents/writing.md
@@ -11,6 +11,14 @@ writing multiple documents with metadata via a multipart HTTP request. The MarkL
 simplifies the use of this endpoint via the `client.documents.write` method and the `Document`
 class. 
 
+## Table of contents
+{: .no_toc .text-delta }
+
+- TOC
+{:toc}
+
+## Setup
+
 The examples below all assume that you have created a new MarkLogic user named "python-user" as described in the 
 [setup guide](../example-setup.md). In addition, each of the examples below requires the following `Client` instance to be created 
 first:

--- a/docs/rows.md
+++ b/docs/rows.md
@@ -9,6 +9,12 @@ The [MarkLogic REST rows service](https://docs.marklogic.com/REST/client/row-man
 operations for querying for rows via several query languages. The MarkLogic Python client simplifies submitting queries
 for rows and converting responses into useful data structures.
 
+## Table of contents
+{: .no_toc .text-delta }
+
+- TOC
+{:toc}
+
 ## Setup
 
 The examples below require documents to be loaded along with a 
@@ -179,3 +185,17 @@ Printing the `df` object will yield the following:
 2                 Armstrong                      Louis           1901-08-04
 3                  Coltrane                       John           1926-09-23
 ```
+
+## Providing additional arguments
+
+The `client.rows.query` method provides a `**kwargs` argument, so you can pass in any other arguments you would
+normally pass to `requests`. For example:
+
+```
+response = client.rows.query("op.fromView('example', 'musician')", params={"database": "Documents"})
+```
+
+Please see [the rows endpoint documentation](https://docs.marklogic.com/REST/POST/v1/rows) for 
+information on additional parameters. If you are submitting a GraphQL query, then see 
+[the GraphQL endpoint documentation](https://docs.marklogic.com/REST/POST/v1/rows/graphql) for 
+information on parameters for that endpoint.

--- a/docs/transactions.md
+++ b/docs/transactions.md
@@ -13,6 +13,14 @@ via a `Transaction` class that is also a
 thereby allowing it to handle committing or rolling back the transaction without any user 
 involvement.
 
+## Table of contents
+{: .no_toc .text-delta }
+
+- TOC
+{:toc}
+
+## Using a transaction
+
 The following example demonstrates writing documents via multiple calls to MarkLogic, 
 all within the same REST API transaction; the example depends on first following the 
 instructions in the [setup guide](example-setup.md):


### PR DESCRIPTION
The main thing is the kwargs info for eval/rows; it looks like we'll have to add that to each page, as if it's in one place, it'll be easily missed. 

Added a TOC as well to make the pages nicer. 