### PR TITLE
MLE-29695 update Jenkins pipeline to use python 3.13

### DIFF
--- a/.copyrightconfig
+++ b/.copyrightconfig
@@ -10,4 +10,4 @@ startyear: 2023
 #   - Use sparingly (third_party, generated, binary assets)
 #   - Dotfiles already skipped automatically
 # Enable by removing the leading '# ' from the next line and editing values.
-filesexcluded: .github/*, *.md, Jenkinsfile, gradle/*, *.yml, *.gradle, *.properties, gradlew, gradlew.bat, CODEOWNERS, *.lock, *.toml, *.md, *version
+filesexcluded: .github/*, *.md, Jenkinsfile, gradle/*, *.yml, *.gradle, *.properties, gradlew, gradlew.bat, CODEOWNERS, *.lock, *.toml, *.md, *version, *.json

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,6 +7,7 @@ pipeline{
     environment{
         JAVA_HOME_DIR="/home/builder/java/jdk-17.0.2"
         GRADLE_DIR   =".gradle"
+        PYTHON313_DIR="/home/builder/python/Python-3.13.7/bin"
     }
 
     options {
@@ -39,9 +40,12 @@ pipeline{
               sh label:'Run tests', script: '''#!/bin/bash
                 set -e
                 cd marklogic-python-client
-                python -m venv .venv;
+                export PATH=$PYTHON313_DIR:$PATH;
+                python3.13 --version;
+                python3.13 -m venv .venv;
                 source .venv/bin/activate;
-                pip install poetry;
+                python --version;
+                python -m pip install poetry;
                 poetry install;
                 pytest --junitxml=TestReport.xml || true
               '''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ pipeline{
     environment{
         JAVA_HOME_DIR="/home/builder/java/jdk-17.0.2"
         GRADLE_DIR   =".gradle"
-        PYTHON313_DIR="/home/builder/python/Python-3.13.7/bin"
+        PYTHON313_BIN="/home/builder/python/Python-3.13.7/bin"
     }
 
     options {
@@ -40,13 +40,13 @@ pipeline{
               sh label:'Run tests', script: '''#!/bin/bash
                 set -e
                 cd marklogic-python-client
-                export PATH=$PYTHON313_DIR:$PATH;
-                python3.13 --version;
-                python3.13 -m venv .venv;
-                source .venv/bin/activate;
-                python --version;
-                python -m pip install poetry;
-                poetry install;
+                export PATH="${PYTHON313_BIN}:${PATH}"
+                python3.13 --version
+                python3.13 -m venv .venv
+                source .venv/bin/activate
+                python --version
+                python -m pip install poetry
+                poetry install
                 pytest --junitxml=TestReport.xml || true
               '''
               junit 'marklogic-python-client/TestReport.xml'

--- a/test-app/src/main/ml-config/security/roles/python-tester.json
+++ b/test-app/src/main/ml-config/security/roles/python-tester.json
@@ -23,6 +23,11 @@
             "privilege-name": "xdbc:invoke",
             "action": "http://marklogic.com/xdmp/privileges/xdbc-invoke",
             "kind": "execute"
+        },
+        {
+        "privilege-name": "xdmp-invoke",
+        "action": "http://marklogic.com/xdmp/privileges/xdmp-invoke",
+        "kind": "execute"
         }
     ]
 }

--- a/tests/test_rows_update.py
+++ b/tests/test_rows_update.py
@@ -16,7 +16,7 @@ def test_update_dsl_fromDocDescriptors(client):
         const docDescriptors = [
             {{
                 uri:"{doc_uri}",
-                doc:'{json.dumps(doc_contents)}',
+                doc:{json.dumps(doc_contents)},
                 permissions: {json.dumps(doc_permissions)}
             }}
         ];

--- a/tests/test_rows_update.py
+++ b/tests/test_rows_update.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# Copyright (c) 2023-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 
 
 import json


### PR DESCRIPTION
This project requires Python 3.10+ while the default python in Jenkins agents in 'devExpLinuxPool' is Python 3.9.16. Updated Jenkinsfile to explicitly use Python 3.13 in the pipeline stage. 